### PR TITLE
applied patch to automatically identify RaspberryMatic/CCU2

### DIFF
--- a/startup.sh
+++ b/startup.sh
@@ -17,15 +17,32 @@ if [ ! -e $USER_DIR ] ; then
   
   $BASE_DIR/install.tcl
 
+else
+
+  # make sure cloudmatic button is always present
+  if ! grep -q "ID mh CONFIG_NAME CloudMatic" /etc/config/hm_addons.cfg 2>/dev/null; then
+    $BASE_DIR/install.tcl
+  fi
+
 fi
 
-mkdir -p /dev/net
-mknod /dev/net/tun c 10 200
-insmod $BASE_DIR/tun.ko
+if [ ! -d /dev/net ]; then
+  mkdir -p /dev/net
+  if [ ! -e /dev/net/tun ]; then
+    mknod /dev/net/tun c 10 200
+    insmod $BASE_DIR/tun.ko
+  fi
+fi
 
-
-l1=`ifconfig | grep 'eth0' | tr -s ' ' | cut -d ' ' -f5 | tr ':' '-'`
-l2=`ifconfig | grep 'usb0' | tr -s ' ' | cut -d ' ' -f5 | tr ':' '-'` 
+if [[ -e /sys/devices/platform/ccu2-ic200 ]]; then
+  # this is for a CCU2
+  l1=`ifconfig | grep 'eth0' | tr -s ' ' | cut -d ' ' -f5 | tr ':' '-'`
+  l2=`ifconfig | grep 'usb0' | tr -s ' ' | cut -d ' ' -f5 | tr ':' '-'`
+else
+  # this is for RaspberryMatic
+  l1=`grep Serial /proc/cpuinfo | sed 's|Serial||' | sed 's|:||' | sed 's/^[ \t]*//'`
+  l2=`ifconfig | grep 'eth0' | tr -s ' ' | cut -d ' ' -f5 | tr ':' '-'`
+fi
 echo SerialNumber=$l1 > $USER_DIR/ids
 echo BidCoS-Address=$l2 >> $USER_DIR/ids
 

--- a/startup.sh
+++ b/startup.sh
@@ -14,16 +14,17 @@ if [ ! -e $USER_DIR ] ; then
   
   rm -rf $WWW_DIR
   ln -s $BASE_DIR/www $WWW_DIR
-  
+
+fi
+
+# convert from meine-homematic.de to CloudMatic
+if grep -q "ID mh CONFIG_NAME meine-homematic.de" /etc/config/hm_addons.cfg 2>/dev/null; then
+  sed -i 's/CONFIG_NAME meine-homematic.de/CONFIG_NAME CloudMatic/g' /etc/config/hm_addons.cfg
+fi
+
+# make sure cloudmatic button is always present
+if ! grep -q "ID mh CONFIG_NAME CloudMatic" /etc/config/hm_addons.cfg 2>/dev/null; then
   $BASE_DIR/install.tcl
-
-else
-
-  # make sure cloudmatic button is always present
-  if ! grep -q "ID mh CONFIG_NAME CloudMatic" /etc/config/hm_addons.cfg 2>/dev/null; then
-    $BASE_DIR/install.tcl
-  fi
-
 fi
 
 if [ ! -d /dev/net ]; then

--- a/user/cleanup.sh
+++ b/user/cleanup.sh
@@ -37,7 +37,14 @@ ln -s $BASE_DIR/www $WWW_DIR
   
 $BASE_DIR/install.tcl
 
-l1=`ifconfig | grep 'eth0' | tr -s ' ' | cut -d ' ' -f5 | tr ':' '-'`
-l2=`ifconfig | grep 'usb0' | tr -s ' ' | cut -d ' ' -f5 | tr ':' '-'` 
+if [[ -e /sys/devices/platform/ccu2-ic200 ]]; then
+  # this is for a CCU2
+  l1=`ifconfig | grep 'eth0' | tr -s ' ' | cut -d ' ' -f5 | tr ':' '-'`
+  l2=`ifconfig | grep 'usb0' | tr -s ' ' | cut -d ' ' -f5 | tr ':' '-'`
+else
+  # this is for RaspberryMatic
+  l1=`grep Serial /proc/cpuinfo | sed 's|Serial||' | sed 's|:||' | sed 's/^[ \t]*//'`
+  l2=`ifconfig | grep 'eth0' | tr -s ' ' | cut -d ' ' -f5 | tr ':' '-'`
+fi
 echo SerialNumber=$l1 > /etc/config/addons/mh/ids
 echo BidCoS-Address=$l2 >> /etc/config/addons/mh/ids


### PR DESCRIPTION
This patch applies changes to automatically identify if the add-on is running on RaspberryMatic or a CCU2 and acts upon it in startup.sh and user/cleanup.sh.