### PR TITLE
we call all binaries directly from /opt/mh

### DIFF
--- a/user/dienstanngx.sh
+++ b/user/dienstanngx.sh
@@ -12,14 +12,7 @@ ADDONDIR=/usr/local/etc/config/addons/mh
 /bin/busybox logger -t homematic -p user.info "Reverse Proxy wird aktiviert"
 v2=`cp $ADDONDIR/dienstan $ADDONDIR/dienstngx`
 
-if [[ -e /sys/devices/platform/ccu2-ic200 ]]; then
-  # CCU2
-  Processname=nginx
-else
-  # RaspberryMatic
-  Processname=nginx.pi
-fi
-
+Processname=nginx
 if [ ! -n "`pidof $Processname`" ] ; then  
 	/bin/busybox logger -t homematic -p user.info "Reverse Proxy Dienst wird gestartet"
 	ovstart=`/opt/mh/user/$Processname`

--- a/user/dienstanzbx.sh
+++ b/user/dienstanzbx.sh
@@ -17,6 +17,6 @@ if [ -e $ADDONDIR/zabbix.conf ] ; then
 	Processname=zabbix_agentd
 	if [ ! -n "`pidof $Processname`" ] ; then  
 		/bin/busybox logger -t homematic -p user.info "CloudMatic monitoring Dienst wird gestartet"
-		ovstart=`/etc/config/addons/mh/zabbix_agentd -c /etc/config/addons/mh/zabbix.conf >/dev/null 2>&1`
+		ovstart=`/opt/mh/user/zabbix_agentd -c /etc/config/addons/mh/zabbix.conf >/dev/null 2>&1`
 	fi
 fi

--- a/user/dienstausngx.sh
+++ b/user/dienstausngx.sh
@@ -12,18 +12,8 @@ ADDONDIR=/usr/local/etc/config/addons/mh
 /bin/busybox logger -t homematic -p user.info "Reverse proxy wird deaktiviert"
 v2=`cp $ADDONDIR/dienstaus $ADDONDIR/dienstngx`
 
-if [[ -e /sys/devices/platform/ccu2-ic200 ]]; then
-  # CCU2
-  Processname=nginx
-else
-  # RaspberryMatic
-  Processname=nginx.pi
-fi
-
+Processname=nginx
 if [ -n "`pidof $Processname`" ] ; then  
    /bin/busybox logger -t homematic -p user.info "Reverse Proxy wurde herunter gefahren"
    dummy=`killall -9 $Processname`
 fi
-
-
-

--- a/user/loophammer.sh
+++ b/user/loophammer.sh
@@ -49,14 +49,14 @@ ADDONDIR=/usr/local/etc/config/addons/mh
 		Processname=zabbix_agentd
 		if [ ! -n "`pidof $Processname`" ] ; then  
 			/bin/busybox logger -t homematic -p user.info "CloudMatic monitoring Dienst wird gestartet"
-			ovstart=`/etc/config/addons/mh/zabbix_agentd -c /etc/config/addons/mh/zabbix.conf >/dev/null 2>&1`
+			ovstart=`/opt/mh/user/zabbix_agentd -c /etc/config/addons/mh/zabbix.conf >/dev/null 2>&1`
 		fi
 	fi
 
 	Processname=nginx
 	if [ ! -n "`pidof $Processname`" ] ; then  
 		/bin/busybox logger -t homematic -p user.info "Reverse Proxy Dienst wird gestartet"
-		ovstart=`/usr/local/etc/config/addons/mh/nginx`
+		ovstart=`/opt/mh/user/nginx`
 	fi
  else
     #
@@ -92,7 +92,3 @@ ADDONDIR=/usr/local/etc/config/addons/mh
 			dummy=`killall -9 nginx`
 		fi
 	fi
-	
-	
-
-	

--- a/user/startopenvpn
+++ b/user/startopenvpn
@@ -6,7 +6,7 @@ WWWDIR=/etc/config/addons/www/$ADDONNAME
 CONFIGDIR=/usr/local/etc/config
 RCDDIR=$CONFIGDIR/rc.d
 
-openvpn=$ADDONDIR/openvpn
+openvpn=/opt/mh/openvpn
 piddir=/var/run/openvpn
 
 case "$1" in


### PR DESCRIPTION
This patch makes sure all binaries are called from /opt/mh rather than /etc/config so that the right binaries are used. In addition, the explicit call of "nginx.pi" isn't required because the cloudmatic package of raspberrymatic makes sure to install the right binary as the main "nginx" binary and omits the ccu2-version binary.
