### PR TITLE
this fixes issues with not properly rendering the cloudmatic addon webpages

### DIFF
--- a/www/clregister.cgi
+++ b/www/clregister.cgi
@@ -14,8 +14,7 @@ set user_has_account unknown
 set content [::HomeMatic::Util::LoadFile "/etc/config/addons/mh/mhcfg"]
 catch { [regexp -line {user_has_account=(.*)} $content dummy user_has_account] }
 
-puts {
-<!DOCTYPE html>
+puts { <!DOCTYPE html>
 <html>
   <head>
     <link href="http://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">

--- a/www/dotest.cgi
+++ b/www/dotest.cgi
@@ -15,8 +15,7 @@ catch { [regexp -line {user_has_account=(.*)} $content dummy user_has_account] }
 
 
 
-puts {
-<!DOCTYPE html>
+puts { <!DOCTYPE html>
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />

--- a/www/dotest2.cgi
+++ b/www/dotest2.cgi
@@ -15,8 +15,7 @@ catch { [regexp -line {user_has_account=(.*)} $content dummy user_has_account] }
 
 
 
-puts {
-<!DOCTYPE html>
+puts { <!DOCTYPE html>
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />

--- a/www/index.cgi
+++ b/www/index.cgi
@@ -19,14 +19,13 @@ set register_pending unknown
 set content [::HomeMatic::Util::LoadFile "/etc/config/addons/mh/register_pending"]
 catch { [regexp -line {status=(.*)} $content dummy register_pending] }
 
-puts {
-<!DOCTYPE html>
+puts { <!DOCTYPE html>
 <html>
   <head>
     <link type="text/css" rel="stylesheet" href="css/materialize.min.css"  media="screen,projection">
     <link type="text/css" rel="stylesheet" href="css/cloudmatic.css"  media="screen,projection">
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <title>CloudMatic (v2017020901)</title>
+    <title>CloudMatic (v20180325)</title>
   </head>
 <body>
 <script>

--- a/www/transferkey.cgi
+++ b/www/transferkey.cgi
@@ -16,8 +16,7 @@ catch { [regexp -line {user_has_account=(.*)} $content dummy user_has_account] }
 
 
 
-puts {
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+puts { <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />


### PR DESCRIPTION
On newer RaspberryMatic system versions due to DOCTYPE not being output in the right form. This caused the HTML source code to be displayed instead. This PR fixes this issue somehow.

See https://github.com/jens-maus/RaspberryMatic/issues/293 for more information.

Please note that this needs to be integrated in the "automatic cloudmatic update" because all the addon relevant things seem to be overwritten once the automatic update is triggered by cloudmatic.

Please integrate this ASAP to fix problems with latest RaspberryMatic.