### PR TITLE
added missing "Content-Type:" response header

### DIFF
--- a/www/clregister.cgi
+++ b/www/clregister.cgi
@@ -14,7 +14,10 @@ set user_has_account unknown
 set content [::HomeMatic::Util::LoadFile "/etc/config/addons/mh/mhcfg"]
 catch { [regexp -line {user_has_account=(.*)} $content dummy user_has_account] }
 
-puts { <!DOCTYPE html>
+puts "Content-Type: text/html; charset=utf-8"
+
+puts {
+<!DOCTYPE html>
 <html>
   <head>
     <link href="http://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
@@ -22,6 +25,7 @@ puts { <!DOCTYPE html>
     <link type="text/css" rel="stylesheet" href="css/materialize.min.css"  media="screen,projection">
     <link type="text/css" rel="stylesheet" href="css/cloudmatic.css"  media="screen,projection">
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <title>CloudMatic</title>
   </head>
 <body>

--- a/www/dotest.cgi
+++ b/www/dotest.cgi
@@ -13,9 +13,10 @@ set user_has_account unknown
 set content [::HomeMatic::Util::LoadFile "/etc/config/addons/mh/mhcfg"]
 catch { [regexp -line {user_has_account=(.*)} $content dummy user_has_account] }
 
+puts "Content-Type: text/html; charset=utf-8"
 
-
-puts { <!DOCTYPE html>
+puts {
+<!DOCTYPE html>
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />

--- a/www/dotest2.cgi
+++ b/www/dotest2.cgi
@@ -13,9 +13,10 @@ set user_has_account unknown
 set content [::HomeMatic::Util::LoadFile "/etc/config/addons/mh/mhcfg"]
 catch { [regexp -line {user_has_account=(.*)} $content dummy user_has_account] }
 
+puts "Content-Type: text/html; charset=utf-8"
 
-
-puts { <!DOCTYPE html>
+puts {
+<!DOCTYPE html>
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />

--- a/www/index.cgi
+++ b/www/index.cgi
@@ -19,13 +19,17 @@ set register_pending unknown
 set content [::HomeMatic::Util::LoadFile "/etc/config/addons/mh/register_pending"]
 catch { [regexp -line {status=(.*)} $content dummy register_pending] }
 
-puts { <!DOCTYPE html>
+puts "Content-Type: text/html; charset=utf-8"
+
+puts {
+<!DOCTYPE html>
 <html>
   <head>
     <link type="text/css" rel="stylesheet" href="css/materialize.min.css"  media="screen,projection">
     <link type="text/css" rel="stylesheet" href="css/cloudmatic.css"  media="screen,projection">
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <title>CloudMatic (v20180325)</title>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <title>CloudMatic (v20181025)</title>
   </head>
 <body>
 <script>

--- a/www/transferkey.cgi
+++ b/www/transferkey.cgi
@@ -14,9 +14,10 @@ set user_has_account unknown
 set content [::HomeMatic::Util::LoadFile "/etc/config/addons/mh/mhcfg"]
 catch { [regexp -line {user_has_account=(.*)} $content dummy user_has_account] }
 
+puts "Content-Type: text/html; charset=utf-8"
 
-
-puts { <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+puts {
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />


### PR DESCRIPTION
... which were missing for all html response pages. This was the actual reason for not properly displaying the cloudmatic pages but showing the html source code instead (especially when supplying pages with "X-Content-Type-Options: nosniff" response header active).