### PR TITLE
implemented openvpn wrapper startup script to apply SECLEVEL=0

### DIFF
--- a/openvpn
+++ b/openvpn
@@ -1,1 +1,32 @@
-/usr/sbin/openvpn
+#!/bin/sh
+#
+# openvpn wrapper script to execute openvpn binary with the supplied
+# command options but potentially apply certain modifications beforehand.
+#
+
+OPENVPN=/usr/sbin/openvpn
+OPENVPN_ARGS=$*
+CLIENT_CONF=/var/etc/cloudmatic_openvpn_client.conf
+CLIENT_CRT=/etc/config/addons/mh/client.crt
+
+# extract supplied --config from command args and copy it to the
+# client conf under /var/etc
+CONF=$(echo "${OPENVPN_ARGS}" | sed 's/.* --config \(.*\.conf\) .*/\1/g')
+cp "${CONF}" ${CLIENT_CONF}
+
+# To temporary workaround the still existing security flaw in the CloudMatic
+# infrastructure that SHA1 hashed certificates are still used we make sure the
+# supplied openvpn client conf will contain the 'tls-cipher "DEFAULT:@SECLEVEL=0"'
+# option for the time being. (cf. https://github.com/jens-maus/RaspberryMatic/issues/2442)
+if openssl x509 -in ${CLIENT_CRT} -noout -text | grep -qm1 "sha1WithRSAEncryption"; then
+  if ! grep 'tls-cipher "DEFAULT:@SECLEVEL=0"' ${CLIENT_CONF}; then
+    echo 'tls-cipher "DEFAULT:@SECLEVEL=0"' >>${CLIENT_CONF}
+  fi
+fi
+
+# modify args to contain the new client conf from /var
+OPENVPN_ARGS=$(echo "${OPENVPN_ARGS}" | sed "s|${CONF}|${CLIENT_CONF}|g")
+
+# start openvpn
+# shellcheck disable=SC2086
+${OPENVPN} ${OPENVPN_ARGS}

--- a/openvpn
+++ b/openvpn
@@ -19,8 +19,12 @@ cp "${CONF}" ${CLIENT_CONF}
 # supplied openvpn client conf will contain the 'tls-cipher "DEFAULT:@SECLEVEL=0"'
 # option for the time being. (cf. https://github.com/jens-maus/RaspberryMatic/issues/2442)
 if openssl x509 -in ${CLIENT_CRT} -noout -text | grep -qm1 "sha1WithRSAEncryption"; then
-  if ! grep 'tls-cipher "DEFAULT:@SECLEVEL=0"' ${CLIENT_CONF}; then
-    echo 'tls-cipher "DEFAULT:@SECLEVEL=0"' >>${CLIENT_CONF}
+  # adding SECLEVEL=0 is only supported since openssl 1.1.0, thus check if the
+  # system uses openssl >= 1.1.0 or skip accordingly.
+  if openssl version | awk '$2 ~ /(^0\.)|(^1\.(0\.|0\.0))/ { exit 1 }'; then
+    if ! grep 'tls-cipher "DEFAULT:@SECLEVEL=0"' ${CLIENT_CONF}; then
+      echo 'tls-cipher "DEFAULT:@SECLEVEL=0"' >>${CLIENT_CONF}
+    fi
   fi
 fi
 

--- a/user/loophammer.sh
+++ b/user/loophammer.sh
@@ -20,7 +20,6 @@
 # **************************************************************************************************************************************************
 #
 ADDONDIR=/usr/local/etc/config/addons/mh
-VERSION=`cat /VERSION |grep PRODUCT |awk -F"=" '{ print $2 }'|awk -F"_" '{print $1}'`
 
   #Dienst Status einlesen
   dienst=`/bin/busybox cat $ADDONDIR/dienst`
@@ -38,47 +37,11 @@ VERSION=`cat /VERSION |grep PRODUCT |awk -F"=" '{ print $2 }'|awk -F"_" '{print 
      #
      # Aktuelles Datum ist vor dem Enddatum. VPN starten, falls es nicht läuft
      #
-     
-     # Workaround RaspberryMatic
-     # https://github.com/jens-maus/RaspberryMatic/issues/2442
-     
-     clientConfFilePath="/usr/local/etc/config/addons/mh/client.conf"
-     certificateFilePath="/usr/local/etc/config/addons/mh/client.crt"
-     workaroundTlsCipher="tls-cipher \"DEFAULT:@SECLEVEL=0\""
-     clientConfToUse="$clientConfFilePath"
-     
-     if [ "$VERSION" = "raspmatic" ]; then
-         if [ -f "$clientConfFilePath" ]; then             
-             # Die temporäre Datei nach /var/etc kopieren, um frühere Versionen von RaspberryMatic zu unterstützen
-             clientConfToUse="/var/etc/cloudmatic_openvpn_client.conf"
-             cp "$clientConfFilePath" "$clientConfToUse"
-             # Überprüfen, ob das Zertifikat den Signaturalgorithmus sha1WithRSAEncryption verwendet
-             isSha1WithRSAEncryption=$(openssl x509 -in "$certificateFilePath" -noout -text | grep "Signature Algorithm: sha1WithRSAEncryption")
-             
-             if [ -n "$isSha1WithRSAEncryption" ]; then
-                # sha1WithRSAEncryption wird verwendet
-                if [ ! "$(grep 'tls-cipher "DEFAULT:@SECLEVEL=0"' $clientConfFilePath)" ]; then
-                    echo "$workaroundTlsCipher" >> $clientConfFilePath
-                fi
-             else
-                # sha1WithRSAEncryption wird nicht verwendet
-                # Temporäre Datei erstellen, um die geänderten Daten zu speichern
-                tempClientConfFile=$(mktemp)         
-                       
-                # Die Zeile mit dem angegebenen Inhalt aus der Datei entfernen
-                sed "/$workaroundTlsCipher/d" "$clientConfFilePath" > "$tempClientConfFile"   
-                
-                # Die temporäre Datei in die ursprüngliche Datei umbenennen                                            
-                mv "$tempClientConfFile" "$clientConfToUse"
-             fi
-         fi
-     fi
-     
      Processname=openvpn
      if [ ! -n "`pidof $Processname`" ] ; then  
         if [ $dienst -ge 1 ] ; then
 			/bin/busybox logger -t homematic -p user.info "meine-homematic.de loophammer startet openvpn."
-			ovstart=`/opt/mh/openvpn --daemon --config $clientConfToUse --cd $ADDONDIR`
+			ovstart=`/opt/mh/openvpn --daemon --config $ADDONDIR/client.conf --cd $ADDONDIR`
 		fi 
      fi
 


### PR DESCRIPTION
This PR implements a openvpn wrapper startup script rather than just relinking `/opt/mh/openvpn` to `/usr/sbin/openvpn` so that the tls-cipher workaround for newer openssl/openvpn environments rather than applying this in `loophammer.sh` for every different user environment.

Please note that this is a temporary workaround until the security flaw that the CloudMatic infrastructure is still using obsolete SHA1 hashed certificates is solved by rolling out newer SHA256/SHA384 hashed certificates to improved general VPN security.

This PR refs https://github.com/jens-maus/RaspberryMatic/issues/2442