### PR TITLE
mitigate certain WARNING messages on openvpn startup

### DIFF
--- a/openvpn
+++ b/openvpn
@@ -8,6 +8,7 @@ OPENVPN=/usr/sbin/openvpn
 OPENVPN_ARGS=$*
 CLIENT_CONF=/var/etc/cloudmatic_openvpn_client.conf
 CLIENT_CRT=/etc/config/addons/mh/client.crt
+CLIENT_KEY=/etc/config/addons/mh/client.key
 
 # extract supplied --config from command args and copy it to the
 # client conf under /var/etc
@@ -30,6 +31,16 @@ fi
 
 # modify args to contain the new client conf from /var
 OPENVPN_ARGS=$(echo "${OPENVPN_ARGS}" | sed "s|${CONF}|${CLIENT_CONF}|g")
+
+# make sure that the obsolete ns-cert-type option is replaced by remote-cert-tls
+sed -i 's/ns-cert-type/remote-cert-tls/g' ${CLIENT_CONF}
+
+# disable comp-lzo as compression is discouraged for security reasons
+# (cf. https://community.openvpn.net/openvpn/wiki/DeprecatedOptions)
+sed -i 's/comp-lzo/#comp-lzo/g' ${CLIENT_CONF}
+
+# make sure client.key has the right (safe) permissions before using it
+chmod 600 ${CLIENT_KEY}
 
 # start openvpn
 # shellcheck disable=SC2086

--- a/openvpn
+++ b/openvpn
@@ -37,7 +37,7 @@ sed -i 's/ns-cert-type/remote-cert-tls/g' ${CLIENT_CONF}
 
 # disable comp-lzo as compression is discouraged for security reasons
 # (cf. https://community.openvpn.net/openvpn/wiki/DeprecatedOptions)
-sed -i 's/comp-lzo/#comp-lzo/g' ${CLIENT_CONF}
+#sed -i 's/comp-lzo/#comp-lzo/g' ${CLIENT_CONF}
 
 # make sure client.key has the right (safe) permissions before using it
 chmod 600 ${CLIENT_KEY}


### PR DESCRIPTION
This PR adds some more workarounds for the `/opt/mh/openvpn` wrapper script starting openvpn so that common WARNING messages are mitigated. The mitigated warnings are:

1. `WARNING: --ns-cert-type is DEPRECATED.  Use --remote-cert-tls instead.`
2. `WARNING: file '/usr/local/etc/config/addons/mh/client.key' is group or others accessible`

A third warning (`WARNING: Compression for receiving enabled. Compression has been used in the past to break encryption.`) can however not be mitigated at the moment because the OpenVPN server seems to enforce compression, thought compression is already been discouraged due to the commonly known "[​VORACLE Attack](https://community.openvpn.net/openvpn/wiki/VORACLE)" attack vector. So to also remove the last warning upon startup of openvpn the server infrastructure should either disable compression altogether or set `compress migrate` so that the client conf can decide to either use or not use compression.
